### PR TITLE
docs(utils): add docs for test cases

### DIFF
--- a/tests/unit/fastapi_utils_test.py
+++ b/tests/unit/fastapi_utils_test.py
@@ -20,6 +20,7 @@ class DependencyLimiter(FastAPILimiter):
 
 
 def test_should_split_dependencies_and_middlewares(limit, storage):
+    # Given all 3 limiters are defined
     dependency_limiter = DependencyLimiter(
         limit=limit, storage=storage, strategy=Strategies.MOVING_WINDOW
     )
@@ -30,14 +31,18 @@ def test_should_split_dependencies_and_middlewares(limit, storage):
         limit=limit, storage=storage, strategy=Strategies.MOVING_WINDOW
     )
 
+    # And their order is random
     limiters = [dependency_limiter, total_limiter, ip_limiter]
     random.shuffle(limiters)
 
+    # When spliting dependencies and middlewares
     dependencies, dispatch_functions = split_dependencies_and_middlewares(*limiters)
 
+    # Should have only 1 dependency
     assert len(dependencies) == 1
     assert dependencies.pop().dependency is dependency_limiter
-
+    
+    # And dispatch functions should contain the other 2 limiters
     assert ip_limiter.dispatch in dispatch_functions
     assert total_limiter.dispatch in dispatch_functions
 

--- a/tests/unit/fastapi_utils_test.py
+++ b/tests/unit/fastapi_utils_test.py
@@ -1,5 +1,6 @@
-import random
+import itertools
 import time
+from typing import List, Sequence
 
 import pytest
 from fastapi import Depends
@@ -11,6 +12,8 @@ from throttled.fastapi import (
     TotalLimiter,
     split_dependencies_and_middlewares,
 )
+from throttled.models import Rate
+from throttled.storage import BaseStorage
 from throttled.strategies import Strategies
 
 
@@ -19,32 +22,38 @@ class DependencyLimiter(FastAPILimiter):
         self.limit(str(current_time))
 
 
-def test_should_split_dependencies_and_middlewares(limit, storage):
-    # Given all 3 limiters are defined
-    dependency_limiter = DependencyLimiter(
-        limit=limit, storage=storage, strategy=Strategies.MOVING_WINDOW
-    )
-    ip_limiter = IPLimiter(
-        limit=limit, storage=storage, strategy=Strategies.MOVING_WINDOW
-    )
-    total_limiter = TotalLimiter(
-        limit=limit, storage=storage, strategy=Strategies.MOVING_WINDOW
-    )
+def given_all_limiters(limit: Rate, storage: BaseStorage) -> List[FastAPILimiter]:
+    return [
+        DependencyLimiter(
+            limit=limit, storage=storage, strategy=Strategies.MOVING_WINDOW
+        ),
+        IPLimiter(limit=limit, storage=storage, strategy=Strategies.MOVING_WINDOW),
+        TotalLimiter(limit=limit, storage=storage, strategy=Strategies.MOVING_WINDOW),
+    ]
 
-    # And their order is random
-    limiters = [dependency_limiter, total_limiter, ip_limiter]
-    random.shuffle(limiters)
+
+def fastapi_dependencies_are_the_same(
+    dependencies_1: Sequence[Depends], dependencies_2: Sequence[Depends]
+) -> bool:
+    for dep_1, dep_2 in itertools.zip_longest(dependencies_1, dependencies_2):
+        if dep_1.dependency is not dep_2.dependency:
+            return False
+    return True
+
+
+def test_should_split_dependencies_and_middlewares(limit, storage):
+    # Given 2 middleware limiters and 1 limiter as dependency
+    limiters = given_all_limiters(limit, storage)
+    dependency_limiiter, ip_limiter, total_limiter = limiters
 
     # When spliting dependencies and middlewares
     dependencies, dispatch_functions = split_dependencies_and_middlewares(*limiters)
 
-    # Should have only 1 dependency
-    assert len(dependencies) == 1
-    assert dependencies.pop().dependency is dependency_limiter
-    
-    # And dispatch functions should contain the other 2 limiters
-    assert ip_limiter.dispatch in dispatch_functions
-    assert total_limiter.dispatch in dispatch_functions
+    # Then it should return only limiter as dependency
+    assert fastapi_dependencies_are_the_same(dependencies, [Depends(dependency_limiiter)])
+
+    # And the other two limiters dispatch method as dispatch functions
+    assert dispatch_functions == [ip_limiter.dispatch, total_limiter.dispatch]
 
 
 def test_should_raise_if_not_callable_limiter():


### PR DESCRIPTION
**Atenção**: Esse PR é apenas uma sugestão, não deve ser mergeado, mas pense nas possibilidades apresentadas. Abraço!

Edit: Percebi que você já tem o padrão Given, Then e When em outros testes, achei bem bacana! Meu ponto é que é válido usar esse mesmo padrão em testes que não sejam só de aceitação / e2e, mas de forma geral tá show!

Uma das coisas que eu vejo como valioso é nos atentarmos com a legibilidade dos testes. Segundo o Uncle Bob, os testes 
devem ser ainda mais cuidadosamente escritos para que sejam fáceis de entender e escrever. O que eu fiz aqui foi colocar comentários para separar as partes do seu código em [Given, Then e When](https://martinfowler.com/bliki/GivenWhenThen.html). Apesar de ser razoável ter receio em colocar comentários em código, nesses casos é útil para a separação das partes do teste. O que você poderia fazer também é criar as próprias funções que possuem esses nomes e já façam parte do código, algo como: 
```python
dependency_limiter, ip_limiter, total_limiter = givenAllLimiters()
limiters = and_they_are_in_random_order([dependency_limiter, total_limiter, ip_limiter])

dependencies, dispatch_functions = split_dependencies_and_middlewares(*limiters)

should_have_one_dependency(dependencies)
and_should_have_two_dispatch_functions(dispatch_functions)
```

Perceba que com essa estrutura você também diminui a quantidade de código que você tem que ler dentro do teste. Cada linha de código a mais num teste é um esforço mental a mais para entendê-lo, portanto eu sugiro você pensar sempre em deixar bem enxuto e utilizar funções privadas para fazer cada parte do teste. Outra sugestão é usar alguma lib para te ajudar a escrever testes, pois algumas partes como  
```python
assert len(dependencies) == 1
assert dependencies.pop().dependency is dependency_limiter
```

poderiam ser reduzidas com matchers que verifiquem a igualdade entre arrays, algo como: `assert_equals(dependencies, [dependency_limiter])`. Bem mais enxuto, né?